### PR TITLE
Copy .gfs file rather than creating it each time

### DIFF
--- a/Land_Registry_Cadastral_Parcels.gfs
+++ b/Land_Registry_Cadastral_Parcels.gfs
@@ -1,0 +1,36 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>PREDEFINED</Name>
+    <ElementPath>PREDEFINED</ElementPath>
+    <!--POLYGON-->
+    <GeometryType>3</GeometryType>
+    <SRSName>urn:ogc:def:crs:EPSG::27700</SRSName>
+    <PropertyDefn>
+      <Name>INSPIREID</Name>
+      <ElementPath>INSPIREID</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>LABEL</Name>
+      <ElementPath>LABEL</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>NATIONALCADASTRALREFERENCE</Name>
+      <ElementPath>NATIONALCADASTRALREFERENCE</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>VALIDFROM</Name>
+      <ElementPath>VALIDFROM</ElementPath>
+      <Type>String</Type>
+      <Width>24</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>BEGINLIFESPANVERSION</Name>
+      <ElementPath>BEGINLIFESPANVERSION</ElementPath>
+      <Type>String</Type>
+      <Width>24</Width>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/download.sh
+++ b/download.sh
@@ -18,7 +18,8 @@ while IFS="," read -r name filename url; do
 	if [ -f "data/$dirname.shp" ]; then
 		echo "Skipping conversion"
 	else
-		ogr2ogr -f "ESRI Shapefile" "data/$dirname.shp" "data/$dirname/Land_Registry_Cadastral_Parcels.gml"
+		cp Land_Registry_Cadastral_Parcels.gfs "data/$dirname/Land_Registry_Cadastral_Parcels.gfs"
+		ogr2ogr -append -f SQLite -dialect SQLite -sql "SELECT geometry FROM PREDEFINED" combined.sqlite "data/$dirname/Land_Registry_Cadastral_Parcels.gml"
 	fi
 done < "local authorities.csv"
 


### PR DESCRIPTION
The script appears to freeze on the ogr2ogr step. It looks like this is due to the GML files. The first time you open these the process tales a long time but in doing so it creates a .gfs file so that subsequent operation is quicker. For EU INSPIRE data most (if not all) of the GML instances that are made available use attributes of GML elements such as xlink:href pointing to a registry with persistent uri. It appears that what is happening is that the file is very slow to open as the uri is inaccessible and we literally have to wait for it to time out! You also see an time out error message or a message stating it cannot resolve the following url:

http://192.168.4.121:8080/geoserver/LR/wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typeName=LR%3APREDEFINED

Fortunately it looks like the Land Registry use the same schema structure for all the England & Wales files. We can therefore just give it the file it needs to speed up the process.

To all downloaded data, add a text file called "Land_Registry_Cadastral_Parcels.gfs" with the following content. This is the same as the ogr created file in all cases with the exception of the fact that I have removed the <DatasetSpecificInfo> block from the file. This block gave the bounding box and the feature count. A test shows it is not necessary.

```
<GMLFeatureClassList>
  <GMLFeatureClass>
    <Name>PREDEFINED</Name>
    <ElementPath>PREDEFINED</ElementPath>
    <!--POLYGON-->
    <GeometryType>3</GeometryType>
    <SRSName>urn:ogc:def:crs:EPSG::27700</SRSName>
    <PropertyDefn>
      <Name>INSPIREID</Name>
      <ElementPath>INSPIREID</ElementPath>
      <Type>Integer</Type>
    </PropertyDefn>
    <PropertyDefn>
      <Name>LABEL</Name>
      <ElementPath>LABEL</ElementPath>
      <Type>Integer</Type>
    </PropertyDefn>
    <PropertyDefn>
      <Name>NATIONALCADASTRALREFERENCE</Name>
      <ElementPath>NATIONALCADASTRALREFERENCE</ElementPath>
      <Type>Integer</Type>
    </PropertyDefn>
    <PropertyDefn>
      <Name>VALIDFROM</Name>
      <ElementPath>VALIDFROM</ElementPath>
      <Type>String</Type>
      <Width>24</Width>
    </PropertyDefn>
    <PropertyDefn>
      <Name>BEGINLIFESPANVERSION</Name>
      <ElementPath>BEGINLIFESPANVERSION</ElementPath>
      <Type>String</Type>
      <Width>24</Width>
    </PropertyDefn>
  </GMLFeatureClass>
</GMLFeatureClassList>
```