### PR TITLE
Add a table name

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -17,12 +17,12 @@ while IFS="," read -r name filename url; do
 	else
 		if [[ $shortname == [A-Z][A-Z][A-Z] ]]; then
 			# Scotland datasets
-			ogr2ogr -append -f SQLite -dialect SQLite -sql "SELECT geometry FROM ${shortname}_bng" combined.sqlite "/vsizip/data/$filename/${shortname}_bng.shp"
+			ogr2ogr -append -f SQLite -dialect SQLite -sql "SELECT geometry FROM ${shortname}_bng" -nln landreg combined.sqlite "/vsizip/data/$filename/${shortname}_bng.shp"
 			touch "data/$shortname.imported"
 		else
 			# England & Wales datasets
 			zip -ru "data/$filename" Land_Registry_Cadastral_Parcels.gfs
-			ogr2ogr -append -f SQLite -dialect SQLite -sql "SELECT geometry FROM PREDEFINED" combined.sqlite "/vsizip/data/$filename/Land_Registry_Cadastral_Parcels.gml"
+			ogr2ogr -append -f SQLite -dialect SQLite -sql "SELECT geometry FROM PREDEFINED" -nln landreg combined.sqlite "/vsizip/data/$filename/Land_Registry_Cadastral_Parcels.gml"
 			touch "data/$shortname.imported"
 		fi
 	fi


### PR DESCRIPTION
By default the table name is "select". This then throws an error in Mapnik (our downstream process outside of this repo) likely as "select" is a common term in SQL. This patch fixes this.